### PR TITLE
Countries gem version 1.2.0 compatibility

### DIFF
--- a/lib/iso/swift.rb
+++ b/lib/iso/swift.rb
@@ -1,5 +1,5 @@
 require 'yaml'
-require 'iso3166'
+require 'countries'
 
 module ISO
 


### PR DESCRIPTION
Countries gem v1.2.0 has removed `iso3166.rb`. Hence we must require the `countries.rb` instead to bootstrap the dependency. This is now OK as the top level `Country` class has been removed in v1.0  (see PR #1 which fixed that issue).
