### PR TITLE
Add support for the recent "countries" gem versions

### DIFF
--- a/iso.gemspec
+++ b/iso.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "countries"
+  spec.add_runtime_dependency "countries", ">= 4.2"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"

--- a/lib/iso/swift.rb
+++ b/lib/iso/swift.rb
@@ -88,7 +88,7 @@ module ISO
         @data["country_code"] = swift[4..5]
         country = ISO3166::Country.new(country_code)
         if country
-          @data["country_name"] = country.name
+          @data["country_name"] = country.iso_short_name
         else
           @errors << :bad_country_code
         end

--- a/lib/iso/version.rb
+++ b/lib/iso/version.rb
@@ -1,3 +1,3 @@
 module ISO
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end


### PR DESCRIPTION
The current version relies on an obsolete version of the "countries" gem. Added support for the recent version (4.2 or later) and as a result dropped support for the older versions as the "countries" API changed significantly in v4.2.